### PR TITLE
Fix binary conversion and missing time zones

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverter.java
@@ -76,7 +76,7 @@ public class MapiTypeConverter {
            mapitype.setIsArray(true);
            map.put(MapiPropertyType.ApplicationTimeArray, mapitype);
 
-           mapitype = new MapiTypeConverterMapEntry(Byte[].class);
+           mapitype = new MapiTypeConverterMapEntry(byte[].class);
            mapitype.setParse(IFunctions.Base64Decoder.INSTANCE);
            mapitype.setConvertToString(IFunctions.Base64Encoder.INSTANCE);
            map.put(MapiPropertyType.Binary, mapitype);

--- a/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverterMapEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverterMapEntry.java
@@ -60,6 +60,7 @@ public class MapiTypeConverterMapEntry {
           Map<Class<?>, Object> map = new HashMap<Class<?>, Object>();
 
           map.put(Boolean.class, false);
+          map.put(byte[].class, null);
           map.put(Byte[].class, null);
           map.put(Short.class, new Short((short) 0));
           map.put(Integer.class, 0);

--- a/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
@@ -241,6 +241,7 @@ public final class TimeZoneUtils {
     map.put("America/Porto_Acre", "SA Pacific Standard Time");
     map.put("America/Porto_Velho", "SA Western Standard Time");
     map.put("America/Puerto_Rico", "SA Western Standard Time");
+    map.put("America/Punta_Arenas", "Pacific SA Standard Time");
     map.put("America/Rainy_River", "Central Standard Time");
     map.put("America/Rankin_Inlet", "Central Standard Time");
     map.put("America/Recife", "SA Eastern Standard Time");
@@ -465,6 +466,7 @@ public final class TimeZoneUtils {
     map.put("Etc/Zulu", "UTC");
     map.put("Europe/Amsterdam", "W. Europe Standard Time");
     map.put("Europe/Andorra", "W. Europe Standard Time");
+    map.put("Europe/Astrakhan", "Russia Time Zone 3");
     map.put("Europe/Athens", "GTB Standard Time");
     map.put("Europe/Belfast", "GMT Standard Time");
     map.put("Europe/Belgrade", "Central Europe Standard Time");
@@ -485,6 +487,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Jersey", "GMT Standard Time");
     map.put("Europe/Kaliningrad", "Kaliningrad Standard Time");
     map.put("Europe/Kiev", "FLE Standard Time");
+    map.put("Europe/Kirov", "Russian Standard Time");
     map.put("Europe/Lisbon", "GMT Standard Time");
     map.put("Europe/Ljubljana", "Central Europe Standard Time");
     map.put("Europe/London", "GMT Standard Time");
@@ -505,6 +508,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Samara", "Russia Time Zone 3");
     map.put("Europe/San_Marino", "W. Europe Standard Time");
     map.put("Europe/Sarajevo", "Central European Standard Time");
+    map.put("Europe/Saratov", "Russia Time Zone 3");
     map.put("Europe/Simferopol", "Russian Standard Time");
     map.put("Europe/Skopje", "Central European Standard Time");
     map.put("Europe/Sofia", "FLE Standard Time");
@@ -512,6 +516,7 @@ public final class TimeZoneUtils {
     map.put("Europe/Tallinn", "FLE Standard Time");
     map.put("Europe/Tirane", "Central Europe Standard Time");
     map.put("Europe/Tiraspol", "GTB Standard Time");
+    map.put("Europe/Ulyanovsk", "Russia Time Zone 3");
     map.put("Europe/Uzhgorod", "FLE Standard Time");
     map.put("Europe/Vaduz", "W. Europe Standard Time");
     map.put("Europe/Vatican", "W. Europe Standard Time");


### PR DESCRIPTION
 - fix: wrong type registered for binary props, was Byte[] but should
have been byte[]
 - fix: define missing JDK 1.8.0_172 timezones in TimeZoneUtils.java (fixes unit tests)
